### PR TITLE
Mobile - Navigation menu stays open after redirect on membership page

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -475,6 +475,7 @@ export default async function decorate(block) {
     if (membershipsHoverContent.style.display === 'flex') {
       membershipsHoverContent.style.display = 'none';
       membershipDiv.className = 'before-click';
+      toggleMenu(nav, nav);
     } else {
       registerHoverContent.style.display = 'none';
       registerDiv.className = 'before-click';


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](https://github.com/hlxsites/24petwatch/issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #[PM-467](https://pethealthinc.atlassian.net/browse/PM-467)

Bug Fixes: Call toggleMenu on membership in-page anchor links to close open mobile menu

Test URLs:

Before: https://main--24petwatch--hlxsites.hlx.page/lost-pet-protection/membership
After: https://bugfix-mobile-nav-redirect-visibility--24petwatch--hlxsites.hlx.page/lost-pet-protection/membership