### PR TITLE
Added condition to load paid blog header fragment for paid blog template

### DIFF
--- a/blocks/header-paid/header-paid.js
+++ b/blocks/header-paid/header-paid.js
@@ -27,9 +27,17 @@ function instrumentTrackingEvents(header) {
 }
 
 export default async function decorate(block) {
+  // default paid header
   let baseHeaderUrl = '/fragments/us/header-paid';
   if (isCanada) {
     baseHeaderUrl = '/fragments/ca/header-paid';
+  }
+  // paid blog page header
+  if (document.body.className.includes('paid-blog-page')) {
+    baseHeaderUrl = '/fragments/us/header-paid-blog';
+    if (isCanada) {
+      baseHeaderUrl = '/fragments/ca/header-paid-blog';
+    }
   }
 
   const headerPaidContent = await loadFragment(baseHeaderUrl);


### PR DESCRIPTION
Added 2 new fragments for header:

- fragments > us> header-paid-blog
- fragments >  ca > header-paid-blog

The new header fragment will be used on any page using Template : paid-blog-page 

“Get Started” CTA on the paid blog template should go to: /lost-pet-protection/membership
“Get Started” CTA on the paid pages should go to: /lost-pet-protection/lps-quote

paid page: https://feature-pm-556-paid-blog-header--24petwatch--hlxsites.hlx.page/paid/membership
Paid blog page: https://feature-pm-556-paid-blog-header--24petwatch--hlxsites.hlx.page/paid-blog-page

Fix #[<gh-issue-id>](https://pethealthinc.atlassian.net/browse/PM-556)

Test URLs:
- Before: https://main--24petwatch--hlxsites.hlx.page/paid-blog-page
- After: https://feature-pm-556-paid-blog-header--24petwatch--hlxsites.hlx.page/paid-blog-page






















