### PR TITLE
dataLayer updates: wrap tracking data inside ecommerce object

### DIFF
--- a/blocks/thank-you/thank-you.js
+++ b/blocks/thank-you/thank-you.js
@@ -164,17 +164,19 @@ export default async function decorate() {
   contentColumn.appendChild(totals);
 
   const trackingData = {
-    microchip_number: petSummaries[0].microChipNumber,
-    product_type: petSummaries[0].membershipName,
-    transaction_id: externalTransactionID,
-    affiliation: '24petwatch',
-    tax: summary.salesTaxes,
-    payment_type: paymentMethod,
-    value: summary.totalDueToday,
-    shipping: petSummaries[0].nonInsurancePetSummary.shipping,
-    coupon: nonInsPromoCode,
-    flow: cartFlow,
-    customerid: getOwnerDetails.id,
+    ecommerce: {
+      microchip_number: petSummaries[0].microChipNumber,
+      product_type: petSummaries[0].membershipName,
+      transaction_id: externalTransactionID,
+      affiliation: '24petwatch',
+      tax: summary.salesTaxes,
+      payment_type: paymentMethod,
+      value: summary.totalDueToday,
+      shipping: petSummaries[0].nonInsurancePetSummary.shipping,
+      coupon: nonInsPromoCode,
+      flow: cartFlow,
+      customerid: getOwnerDetails.id,
+    },
   };
 
   // send the GTM event


### PR DESCRIPTION
This change requires the existing data in DL to be wrapped inside an 'ecommerce' object on the thank you page

![image](https://github.com/user-attachments/assets/d8f17e29-4d67-4750-8108-5b58793b6fc9)


[Fix #<gh-issue-id>](https://pethealthinc.atlassian.net/browse/PM-618)

Test URLs:
Before: https://main--24petwatch--hlxsites.hlx.page/
After: https://feature-pm-618-dl-purchase-event--24petwatch--hlxsites.hlx.page/
