### PR TITLE
Sync to Release/Sprint 22 Fast Follow: PM-639 Update 'add to cart' DL product type values

### DIFF
--- a/blocks/plans-quote/form.js
+++ b/blocks/plans-quote/form.js
@@ -670,22 +670,22 @@ export default function formDecoration(block) {
 
   function setDataLayer(data) {
     const dlItems = [];
+    const productTypes = [];
 
     if ('petSummaries' in data) {
       const { petSummaries } = data;
-      let membershipName = '';
       if (petSummaries && petSummaries.length > 0) {
         petSummaries.forEach((pet) => {
-          membershipName = pet.membershipName ?? '';
+          productTypes.push(pet.membershipName ?? '');
           // push each item object to items array
           dlItems.push({
-            item_name: membershipName,
+            item_name: pet.membershipName ?? '',
             currency: currencyValue,
             discount: pet.nonInsurancePetSummary?.discount ?? '',
             item_category: 'membership',
             item_variant: '', // okay to be left empty
             microchip_number: pet.microChipNumber ?? '',
-            product_type: membershipName,
+            product_type: pet.membershipName ?? '',
             price: pet.nonInsurancePetSummary?.amount ?? '',
             quantity: pet.nonInsurancePetSummary?.membership?.quantity ?? '1',
           });
@@ -693,7 +693,7 @@ export default function formDecoration(block) {
 
         const trackingData = {
           ecommerce: {
-            product_type: membershipName,
+            product_type: productTypes.join(', '),
             items: dlItems,
           },
         };


### PR DESCRIPTION
## Jira Ticket ##
[PM-639](https://pethealthinc.atlassian.net/browse/PM-639)

## Purpose ##
Group all memberships purchased, in the ‘product type’ parameter (separated by commas).

## Changes ##
- Add `productTypes` array to be used for `product_type` and `item_name`
- Remove `membershipName` variable and it's uses

## Validate Changes ##
With the Chrome Dev Tools console open and viewing the data layer events (via datalayer checker):

- Complete Step 1
- On Step 2, add a new pet, then select a membership plan, click the Add btn
- Confirm the add to cart DL event that is being sent includes the parent `product_type` property contains multiple membership values that are comma separated.  
----
- Before: https://release-sprint-22-fast-follow--24petwatch--hlxsites.hlx.page/lost-pet-protection/lps-quote
- After: https://feature-pm-639-dl-product-type-group--24petwatch--hlxsites.hlx.page/lost-pet-protection/lps-quote
