### PR TITLE
PM-375: Costco Figo Promotion: Sync to Stage

### DIFF
--- a/blocks/plans-quote/costco-promo.js
+++ b/blocks/plans-quote/costco-promo.js
@@ -1,0 +1,134 @@
+import {
+  PET_PLANS_ANNUAL_URL,
+  LS_KEY_FIGO_COSTCO,
+} from '../../scripts/24petwatch-utils.js';
+import APIClient, { getAPIBaseUrl } from '../../scripts/24petwatch-api.js';
+import { getConfigValue } from '../../scripts/configs.js';
+
+export const COSTCO_FIGO_PROMO_ITEMS = {
+  policyIdKey: 'poid',
+  subId: 'SBSUN000016',
+};
+
+// set eligibility flag based on the following values
+const eligibilityCriteria = {
+  level: ['Executive'],
+  type: ['Costco', 'Employee-family'],
+  status: 'Active',
+  policyStatus: ['Future', 'Active'],
+};
+
+const apiBaseUrl = await getAPIBaseUrl();
+const APIClientObj = new APIClient(apiBaseUrl);
+const costcoFigoService = await getConfigValue('costco-figo-proxy');
+const costcoFigoStoredData = localStorage.getItem(LS_KEY_FIGO_COSTCO);
+const costcoFigoStoredValues = costcoFigoStoredData ? JSON.parse(costcoFigoStoredData) : {};
+const costcoFigosubId = COSTCO_FIGO_PROMO_ITEMS.subId;
+const hasCostcoFigoStored = costcoFigoStoredData !== null;
+
+export const getIsMultiPet = costcoFigoStoredValues.multiPet ?? true;
+export const isCostcoFigo = costcoFigoStoredValues.isEligible ?? false;
+export const getSavedCouponCode = costcoFigoStoredValues.couponCode ?? null;
+export const getSavedPolicyId = costcoFigoStoredValues.policyId ?? null;
+
+// is costco figo flow
+function isCostcoFigoFlow() {
+  return window.location.pathname.endsWith(PET_PLANS_ANNUAL_URL);
+}
+
+// get the data
+async function getCostcoPolicyData(policyId) {
+  let policyData;
+  const payload = {
+    payload: {
+      policyId,
+    },
+  };
+
+  const options = {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  };
+
+  try {
+    const response = await fetch(costcoFigoService, options);
+    if (response.ok) {
+      const costcoMembershipData = await response.json();
+      // if we have a record associated with the policy Id
+      if (costcoMembershipData.records && costcoMembershipData.records.length > 0) {
+        [policyData] = costcoMembershipData.records;
+      }
+    }
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('There was an error fetching policy data:', error);
+  }
+  return policyData;
+}
+
+// check eligibility based on eligibilityCriteria values matching record values
+async function isCostcoFigoEligible(policyId) {
+  let eligibilityFlag = false;
+  const record = await getCostcoPolicyData(policyId);
+  if (record) {
+    const status = record.Status__c ?? null;
+    const type = record.Type__c ?? null;
+    const level = record.Level__c ?? null;
+    const policyStatus = record.Insurance_Policy__r?.Status ?? null;
+
+    if (status === eligibilityCriteria.status
+      && eligibilityCriteria.level.includes(level)
+      && eligibilityCriteria.type.includes(type)
+      && eligibilityCriteria.policyStatus.includes(policyStatus)) {
+      eligibilityFlag = true;
+    }
+  }
+  return eligibilityFlag;
+}
+
+// checks if all promo criteria is met and requests a coupon code
+// sets sessionStorage data for accessing props if needed throughout the order journey
+export async function checkCostcoFigoPromo(policyId, countryCode) {
+  let costcoFigoCouponData = false;
+  if (policyId && countryCode) {
+    if (isCostcoFigoFlow()) {
+      // returns boolean
+      const isEligible = await isCostcoFigoEligible(policyId);
+      if (isEligible) {
+        let costcoPromoData = {};
+        try {
+          // eslint-disable-next-line max-len
+          costcoPromoData = await APIClientObj.assignNextAvailableCoupon(costcoFigosubId, policyId, countryCode);
+          const allowMultiPet = costcoPromoData.allowMultiPet ?? null;
+          const couponCode = costcoPromoData.couponCode ?? null;
+          // eslint-disable-next-line max-len
+          if (allowMultiPet !== null && couponCode !== null && couponCode !== '') {
+            const storedCostcoFigoData = {
+              couponCode,
+              multiPet: allowMultiPet,
+              policyId,
+              isEligible,
+            };
+            // store object for next steps
+            localStorage.setItem(LS_KEY_FIGO_COSTCO, JSON.stringify(storedCostcoFigoData));
+            costcoFigoCouponData = storedCostcoFigoData;
+          }
+        } catch (status) {
+          // eslint-disable-next-line no-console
+          console.log('Failed to get couponCode for:', policyId, ' status:', status);
+        }
+      }
+    }
+  }
+  return costcoFigoCouponData;
+}
+
+// remove storage data
+export async function resetCostcoFigoData() {
+  if (hasCostcoFigoStored) {
+    localStorage.removeItem(LS_KEY_FIGO_COSTCO);
+  }
+}

--- a/blocks/plans-quote/plans-quote.css
+++ b/blocks/plans-quote/plans-quote.css
@@ -76,6 +76,23 @@ main .plans-quote form input:not(:placeholder-shown)~label {
   transform: unset;
 }
 
+main .plans-quote form .wrapper.disabled-field > input {
+  cursor: not-allowed;
+  pointer-events: none;
+  user-select: none;
+  position: relative;
+}
+
+main .plans-quote form .wrapper.disabled-field::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: transparent;
+}
+
 main .plans-quote form .wrapper:not(.flex-wrapper) label {
   padding-bottom: 0;
 }

--- a/blocks/thank-you/thank-you.js
+++ b/blocks/thank-you/thank-you.js
@@ -4,6 +4,7 @@ import {
   COOKIE_NAME_SAVED_OWNER_ID,
   deleteCookie,
   SS_KEY_FORM_ENTRY_URL,
+  LS_KEY_FIGO_COSTCO,
   CURRENCY_CANADA,
   CURRENCY_US,
 } from '../../scripts/24petwatch-utils.js';
@@ -97,6 +98,8 @@ export default async function decorate() {
   deleteCookie(COOKIE_NAME_SAVED_OWNER_ID);
   // unset sessionStorage form entry URL
   sessionStorage.removeItem(SS_KEY_FORM_ENTRY_URL);
+  // unset localStorage values related to Costco promo
+  localStorage.removeItem(LS_KEY_FIGO_COSTCO);
 
   const urlParams = new URLSearchParams(window.location.search);
   const paymentProcessorId = urlParams.get('PaymentProcessorCustomerId');

--- a/scripts/24petwatch-api.js
+++ b/scripts/24petwatch-api.js
@@ -305,4 +305,16 @@ export default class APIClient {
       APIClient.callAPI(`${this.basePath}/${path}`, APIClient.METHOD_POST, params, null, resolve, reject, 'json');
     });
   }
+
+  assignNextAvailableCoupon(subscriberId, externalPolicyId, country) {
+    const path = 'Product/NonInsurance/AssignNextAvailableCoupon';
+    const params = {
+      subscriberId,
+      externalPolicyId,
+      country,
+    };
+    return new Promise((resolve, reject) => {
+      APIClient.callAPI(`${this.basePath}/${path}`, APIClient.METHOD_POST, params, null, resolve, reject, 'json');
+    });
+  }
 }

--- a/scripts/24petwatch-utils.js
+++ b/scripts/24petwatch-utils.js
@@ -19,6 +19,11 @@ export function getQueryParam(param, defaultValue = null) {
   return urlParams.has(param) ? urlParams.get(param) : defaultValue;
 }
 
+export function hasQueryParam(param, defaultValue = false) {
+  const urlParams = new URLSearchParams(window.location.search);
+  return urlParams.has(param) && urlParams.get(param).trim() !== '' ? true : defaultValue;
+}
+
 // ----- dataLayer event helpers -----
 export const DL_EVENTS = {
   add: 'add_to_cart',
@@ -31,6 +36,7 @@ export const DL_EVENTS = {
 // ----- sessionStorage / localStorage helpers -----
 export const SS_KEY_FORM_ENTRY_URL = 'formEntryURL';
 export const SS_KEY_SUMMARY_ACTION = 'summaryAction';
+export const LS_KEY_FIGO_COSTCO = 'costcoFigoPromo';
 
 // ----- cookie helpers -----
 export const COOKIE_NAME_FOR_PET_TAGS = 'ph.PetTagQuote';


### PR DESCRIPTION
## Jira Ticket ##
 [PM-375](https://pethealthinc.atlassian.net/browse/PM-375)

## Purpose ##
Under the epic PM-375 these changes are for all tasks related to the FE flow for a Costco Figo promotion

## Changes ##
See all tasks under https://pethealthinc.atlassian.net/browse/PM-375

1. Get poid (policy Id) from query string if page path is PET_PLANS_ANNUAL_URL (/annual-quote)
2. Validate the policy Id exists is Salesforce records and is eligible for promo based on eligibility criteria (via new proxy service)
3. If valid, request promo from assignNextAvailableCoupon API
4. IF a valid promo is returned, add to promo field and disable input
5. IF multipet is false, on summary flow remove add a pet option and don't persist cart on return after abandoned cart


## Validate Changes ##
See all validation requirements on each task under epic: https://pethealthinc.atlassian.net/browse/PM-375

- Example valid policy from inbound email link: https://release-costco-figo-promotion--24petwatch--hlxsites.hlx.page/lost-pet-protection/annual-quote?poid=0YTVE000000UzFl4AK
- To test invalid, change any characters in value

- Before: https://stage--24petwatch--hlxsites.hlx.page/lost-pet-protection/annual-quote
- After: https://release-costco-figo-promotion--24petwatch--hlxsites.hlx.page/lost-pet-protection/annual-quote