### PR TITLE
Enhance CTA tracking by identifying block names and their indices

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -335,7 +335,14 @@ function instrumentTrackingEvents(main) {
             trackCTAEvent(ctaLocation);
             return;
           } else {
-            trackCTAEvent(null);
+            const containerBlock = e.target.closest('[data-block-name]');
+            const blockList = document.querySelectorAll(`[data-block-name=${containerBlock.dataset.blockName}]`);
+            blockList.forEach((block, key) => {
+              if (block === containerBlock) {
+                ctaLocation = `${containerBlock.dataset.blockName}_${key}`;
+              }
+            });
+            trackCTAEvent(ctaLocation);
             return;
           }
         }


### PR DESCRIPTION
## Jira Ticket ##
Feature: https://pethealthinc.atlassian.net/browse/PM-268

## Purpose ##
cta_click event is missing the cta_location parameter in some cases

## Changes ##
The dataLayer now includes the name and index of the container block in the cta_location parameter for the cta_click event 

## Validate Changes ##
![image](https://github.com/user-attachments/assets/8c99967e-5980-4c6c-b7af-5e9a0638a603)
1. Go to: https://feature-pm-268-cta-location--24petwatch--hlxsites.hlx.page/
2. Inspect any element or [open the developer tools](https://developer.chrome.com/docs/devtools/open/)
3. Go to the Network tab
4. Check The Preserve the logs checkbox ✅
5. Enable the Filters and filter by Fetch/XHR
6. Clear the Network Log 🚫
7. Now click on any cta on the page 🖱️
9. Select the first collect? request
10. Look up for the ep.cta_location under the Payload tab

- Before: https://main--24petwatch--hlxsites.hlx.page/
- After: https://feature-pm-268-cta-location--24petwatch--hlxsites.hlx.page/
