### PR TITLE
PM-796: Add exclusions array for appending ca path to links

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -187,6 +187,8 @@ export function changeDomain(block) {
  */
 export function addCanadaToLinks(block) {
   if (isCanada) {
+    const EXEMPT_PATHS = ['privacy-policy']; // add paths that should not be rewritten
+    // check each link in the block
     block.querySelectorAll('a').forEach((anchor) => {
       if (anchor.getAttribute('rel') === 'alternate') return;
       const url = new URL(anchor.href);
@@ -194,6 +196,8 @@ export function addCanadaToLinks(block) {
       if (url.hostname === window.location.hostname) {
         // change only for internal links
         if (!url.pathname.startsWith('/ca/')) {
+          // if any part of the url is in the exempt list, do not rewrite
+          if (EXEMPT_PATHS.some((path) => url.pathname.includes(path))) return;
           newUrl.pathname = `/ca${url.pathname}`;
           anchor.href = newUrl.toString();
         }


### PR DESCRIPTION
## Jira Ticket ##
[PM-796](https://pethealthinc.atlassian.net/browse/PM-796)

## Purpose ##
When clicking “[Click here](https://www.24petwatch.com/ca/privacy-policy) for the 24Petwatch USA Privacy Policy” on the CA Privacy Policy [page](https://www.24petwatch.com/ca/privacy-policy), the redirected link is appended with /ca (the authored link does not have /ca). Thus the customer is stuck on the CA page and can't switch over.

## Changes ##
The method addCanadaToLinks() enforces all internal links under the /ca/ path are prepended with /ca/.
Removing this function would require a large authoring effort at this point, so the fix is to create an array with exempt paths and condition out any included paths from execution within this method.

## Validate Changes ##
1. On the Canadian privacy-policy, validate that the link to the USA privacy policy is correct
2. On the Canadian footer, check the privacy policy still links the the Canadian privacy policy

Before: https://release-sprint-1-deploy--24petwatch--hlxsites.hlx.page/ca/privacy-policy
After: https://feature-pm-796-appended-geo-path--24petwatch--hlxsites.hlx.page/ca/privacy-policy
