### PR TITLE
Sync to Stage: PM-806: Add DL fallback for cta_locations

### DIFF
--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -299,6 +299,7 @@ function instrumentTrackingEvents(header) {
         // track cta clicks on header
         if (e.target.classList.contains('button')) {
           trackGTMEvent('cta_click', {
+            cta_location: 'header_cta',
             link_text: linkText,
             link_url: linkUrl,
           });

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -335,17 +335,53 @@ function instrumentTrackingEvents(main) {
               ctaLocation = 'body_1_cta';
             } else if (e.target.closest('.callout-get-a-quote2')) {
               ctaLocation = 'body_2_cta';
+            } else {
+              const containerBlock = e.target.closest('[data-block-name]');
+              // if containerBlock is null, fallback to sections
+              if (containerBlock) {
+                const blockList = document.querySelectorAll(`[data-block-name=${containerBlock.dataset.blockName}]`);
+                blockList.forEach((block, key) => {
+                  if (block === containerBlock) {
+                    ctaLocation = `${containerBlock.dataset.blockName}_${key}`;
+                  }
+                });
+              } else {
+                // check for the closest section
+                const parentSection = e.target.closest('.section');
+                if (parentSection) {
+                  const sectionList = document.querySelectorAll('.section');
+                  sectionList.forEach((section, key) => {
+                    if (section === parentSection) {
+                      ctaLocation = `section_${key}`;
+                    }
+                  });
+                }
+              }
             }
             trackCTAEvent(ctaLocation);
             return;
           } else {
             const containerBlock = e.target.closest('[data-block-name]');
-            const blockList = document.querySelectorAll(`[data-block-name=${containerBlock.dataset.blockName}]`);
-            blockList.forEach((block, key) => {
-              if (block === containerBlock) {
-                ctaLocation = `${containerBlock.dataset.blockName}_${key}`;
+            // if containerBlock is null, fallback to sections
+            if (containerBlock) {
+              const blockList = document.querySelectorAll(`[data-block-name=${containerBlock.dataset.blockName}]`);
+              blockList.forEach((block, key) => {
+                if (block === containerBlock) {
+                  ctaLocation = `${containerBlock.dataset.blockName}_${key}`;
+                }
+              });
+            } else {
+              // check for the closest section
+              const parentSection = e.target.closest('.section');
+              if (parentSection) {
+                const sectionList = document.querySelectorAll('.section');
+                sectionList.forEach((section, key) => {
+                  if (section === parentSection) {
+                    ctaLocation = `section_${key}`;
+                  }
+                });
               }
-            });
+            }
             trackCTAEvent(ctaLocation);
             return;
           }


### PR DESCRIPTION
## Jira Ticket ##
[PM-806](https://pethealthinc.atlassian.net/browse/PM-806)

## Purpose ##
On some CTA clicks triggering the trackGTMEvent, we are missing the cta_location in DataLayer.

## Changes ##
There is some custom logic set up in instrumentTrackingEvents() which is not setting the cta_location, due to some CTA's being authored outside of blocks.

- As a fallback, we are now going to capture the closest section as the location when the CTA has not met any of the existing conditionals.
- The header is missing cta_location, this has been added in.


## Validate Changes ##
Review https://pethealthinc.atlassian.net/browse/PM-806 for validation steps.

Before: https://stage--24petwatch--hlxsites.hlx.page
After: https://feature-pm-806-cta-click-dl--24petwatch--hlxsites.hlx.page/
