### PR TITLE
PM-820: add nullish check on anchor for card heading

### DIFF
--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -301,7 +301,7 @@ export default async function decorate(block) {
       } else {
         div.className = 'cards-card-body';
         const h4 = li.querySelector('h4');
-        if (h4) {
+        if (h4 && href) {
           wrapInAnchor(h4, href);
         }
       }


### PR DESCRIPTION
## Jira Ticket ##
[PM-820](https://pethealthinc.atlassian.net/browse/PM-820)

## Purpose / Changes ##
A bug exists on the card block, where if an link doesn't exist, the block code ads an undefined href value on an anchor wrapped around a heading. This link results in a 404.

We are resolving this with a check on href before setting the anchor on a heading:
- Add nullish check on href value before setting anchor on card header

## Validate Changes ##

1. Scroll down the page to a cards section, where the cards have headings: Step 1 - Step 5. 
2. The heading should no longer contain an anchor, resolving the issue of linking to a 404 page.


- Before: https://main--24petwatch--hlxsites.hlx.page/lost-pet-protection/pet-recovery-tips
- After: https://feature-pm-820-card-block--24petwatch--hlxsites.hlx.page/lost-pet-protection/pet-recovery-tips
