### PR TITLE
PM-752: Fixes for HTTPS has Internal Links to HTTP

### DIFF
--- a/plugins/rum-conversion/.eslintrc.js
+++ b/plugins/rum-conversion/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
   rules: {
     // allow reassigning param
     'no-param-reassign': [2, { props: false }],
-    'linebreak-style': ['error', 'unix'],
+    'linebreak-style': 0-,
     'import/extensions': ['error', {
       js: 'always',
     }],

--- a/plugins/rum-conversion/.eslintrc.js
+++ b/plugins/rum-conversion/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
   rules: {
     // allow reassigning param
     'no-param-reassign': [2, { props: false }],
-    'linebreak-style': 0-,
+    'linebreak-style': ['error', 'unix'],
     'import/extensions': ['error', {
       js: 'always',
     }],

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -369,7 +369,7 @@ function cleanLocalhostLinks(main) {
       if (anchor.href.startsWith('http://localhost:3001')) {
         const url = new URL(anchor.href);
         url.hostname = 'www.24petwatch.com';
-        url.scheme = 'https';
+        url.protocol = 'https';
         url.port = '';
         anchor.href = url.toString();
       }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -372,6 +372,8 @@ function cleanLocalhostLinks(main) {
         url.protocol = window.location.protocol;
         url.port = window.location.port;
         anchor.href = url.toString();
+        // remove target="_blank" from localhost links
+        anchor.removeAttribute('target');
       }
     });
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -368,9 +368,9 @@ function cleanLocalhostLinks(main) {
     .forEach((anchor) => {
       if (anchor.href.startsWith('http://localhost:3001')) {
         const url = new URL(anchor.href);
-        url.hostname = 'www.24petwatch.com';
-        url.protocol = 'https';
-        url.port = '';
+        url.hostname = window.location.hostname;
+        url.protocol = window.location.protocol;
+        url.port = window.location.port;
         anchor.href = url.toString();
       }
     });


### PR DESCRIPTION
## Jira Tickets ##
[PM-752](https://pethealthinc.atlassian.net/browse/PM-752)
[PM-748](https://pethealthinc.atlassian.net/browse/PM-748)

## Purpose / Changes ##
Technical SEO resolution fixing broken links, 404s and indexable pages linking to http protocol

To fix this, we are updating the method cleanLocalhostLinks to set the protocol, hostname and port of converted localhost links from the SharePoint docs to the existing window properties.

This enforces that the converted links are set using the current environment properties.

## Validate Changes ##

See https://pethealthinc.atlassian.net/browse/PM-748 for validation instruction.


- Before: https://main--24petwatch--hlxsites.hlx.page
- After: https://feature-pm-752-internal-link-update--24petwatch--hlxsites.hlx.page
