### PR TITLE
Deploy to main: Hotfix for cards aspect ratio

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -469,3 +469,7 @@
     margin: 20px 0 40px;
   }
 }
+
+.cards-pumpkin-wellness .cards > ul > li img {
+  aspect-ratio: unset;
+}


### PR DESCRIPTION
## Purpose ##
This is a hotfix for an issue identified with cards on the insurance page.

## Changes ##
On the section class (pumpkin wellness) we are unsetting the aspect ratio for the cards img.

## Validate Changes ##
changes have been validated by QA with regression against all card block variations.

Before: 
![image](https://github.com/user-attachments/assets/74e4e252-16b1-4fe6-a909-0db7e2c6d362)

After:
![image](https://github.com/user-attachments/assets/19f087dc-9b0b-4f54-b158-5b55179f3ede)


- Before: https://main--24petwatch--hlxsites.hlx.page/lost-pet-protection
- After: https://hotfix-cards-aspect-ratio--24petwatch--hlxsites.hlx.page/lost-pet-protection
