### PR TITLE
Deploy to main: 101800

### DIFF
--- a/blocks/plans-quote/summary-quote.js
+++ b/blocks/plans-quote/summary-quote.js
@@ -139,6 +139,31 @@ export default async function decorateSummaryQuote(block, apiBaseUrl) {
     }
   }
 
+  function checkAutoRenewCheckboxes() {
+    const autoRenewCheckboxes = document.querySelectorAll('.auto-renew-checkbox');
+    let allAutoRenewChecked = true;
+
+    // foreach checkbbox, check if it is checked
+    autoRenewCheckboxes.forEach((checkbox) => {
+      const isChecked = checkbox.checked;
+      if (!isChecked) {
+        allAutoRenewChecked = false;
+      }
+    });
+
+    return allAutoRenewChecked;
+  }
+
+  // checks if the proceed to payment button should be enabled or disabled
+  function checkProceedButton() {
+    const button = document.getElementById('proceedToPayment');
+    const autoRenewChecked = checkAutoRenewCheckboxes();
+    if (button) {
+      // if we don't have purchase summary, disable the button
+      button.disabled = purchaseSummary.summary === undefined || autoRenewChecked === false;
+    }
+  }
+
   Loader.showLoader();
   try {
     ownerData = await APIClientObj.getOwner(ownerId);
@@ -308,7 +333,7 @@ export default async function decorateSummaryQuote(block, apiBaseUrl) {
             <div class="item-info-fragment" id="item-info-fragment-${pet.id}" data-selected-product-id="${selectedProduct.itemId}"></div>
         </div>
         <div class="auto-renew">
-            <div class="auto-renew-checkbox-container"><input type="checkbox" class="auto-renew-checkbox" data-rec-id="${selectedProduct.quoteRecId}" data-pet-id="${selectedProduct.petID}" ${selectedProduct.autoRenew ? ' checked' : ''} /></div>
+            <div class="auto-renew-checkbox-container"><input type="checkbox" class="auto-renew-checkbox" data-rec-id="${selectedProduct.quoteRecId}" data-pet-id="${selectedProduct.petID}" /></div>
             <div class="auto-renew-text">${getAutoRenewTet(selectedProduct.itemId)}</div>
         </div>
     </div>
@@ -415,6 +440,9 @@ export default async function decorateSummaryQuote(block, apiBaseUrl) {
 
   async function updateAutoRenewHandler(target) {
     Loader.showLoader();
+
+    checkProceedButton();
+
     const petID = target.getAttribute('data-pet-id');
     const recID = target.getAttribute('data-rec-id');
     const isChecked = target.checked;
@@ -454,12 +482,7 @@ export default async function decorateSummaryQuote(block, apiBaseUrl) {
     }
   });
 
-  const proceedToPaymentButton = document.getElementById('proceedToPayment');
-
-  if (proceedToPaymentButton) {
-    // if we don't have purchase summary, disable the button
-    proceedToPaymentButton.disabled = purchaseSummary.summary === undefined;
-  }
+  checkProceedButton();
 
   function replaceUrlPlaceholders(urlTemplate, ...values) {
     return urlTemplate.replace(
@@ -467,6 +490,8 @@ export default async function decorateSummaryQuote(block, apiBaseUrl) {
       (match, index) => (typeof values[index] !== 'undefined' ? values[index] : match),
     );
   }
+
+  const proceedToPaymentButton = document.getElementById('proceedToPayment');
 
   proceedToPaymentButton.onclick = async () => {
     try {


### PR DESCRIPTION
## Jira Ticket ##
[PM-101800](https://phits.visualstudio.com/Marketing/_workitems/edit/101800)

## Purpose ##
Adding new logic related to click to cancel:

- Unchecking opt-in checkboxes by default
- Disabled the proceed to payment button until all opt-in's are checked

## Changes ##
By default, the product opt-in checkboxes on the plan summary step have been changed to unchecked by removing a condition.
Adding a method to check all product opt in checkboxes and determine if the 'proceed to payment' button should be enabled or disabled. 
This method will execute on load and in the event handler when checking / unchecking opt-ins

## Validate Changes ##
Changes have been validated by QA, refer to ticker: https://phits.visualstudio.com/Marketing/_workitems/edit/101800

To follow validation steps, select any membership product > proceed to step 2 > 'proceed to payment' should be disabled > uncheck and check the product opt-in for auto renew and observe 'proceed to payment' button toggle between enabled and disabled:

Example product flow: https://feature-101800-ctc--24petwatch--hlxsites.hlx.page/lost-pet-protection/lps-quote

- Before:  https://main--24petwatch--hlxsites.hlx.page/
- After: https://feature-101800-ctc--24petwatch--hlxsites.hlx.page/
