### PR TITLE
feat: Add logic and styling for new PWC  autoRenew options

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -222,6 +222,15 @@ main .lost-pet-data > div div:first-child {
   line-height: 1.938rem;
 }
 
+.columns.lpm-multi > div p {
+  margin-bottom: 0.5rem;
+}
+
+.columns.lpm-multi > div em {
+  color: #646F76;
+  font-size: 0.75rem;
+}
+
 main .columns.cat-dog-background > div > div:last-child {
   margin-top: -310px;
   background-image: url('/images/cat-dog-1.png');
@@ -387,6 +396,10 @@ main .section.cat-dog-background {
 
 .columns.collar-package hr {
   margin: 0;
+}
+
+.columns.lpm-multi > div p:not(:first-of-type) {
+  margin-top: 0;
 }
 
 .columns.transfer-microchip-registration-learn-more p.button-container {

--- a/blocks/plans-quote/plans-quote.css
+++ b/blocks/plans-quote/plans-quote.css
@@ -138,6 +138,16 @@ main .plans-quote.first-step > div > div:nth-child(2) > div > p {
   text-align: center;
 }
 
+main .plans-quote.first-step > div > div:nth-child(2) > div > p > em {
+  display: block;
+  margin-top: 0.5rem; /* 8px */
+  color: #677179;
+  font-size: 0.625rem; /* 10px */
+  font-style: italic;
+  font-weight: 400;
+  line-height: normal;
+}
+
 main .plans-quote form .promocode-wrapper {
   margin-bottom: 3.25rem;
 }
@@ -192,7 +202,8 @@ main .plans-quote.first-step > div > div:nth-child(2) > h2 {
 main .plans-quote.first-step > div > div:nth-child(2) > div > p > span.icon
 {
   height: 65px;
-  width: 65px;
+  width: auto;
+  max-width: 120px;
 }
 
 main .plans-quote.summary-quote > div.item > div.item-header {
@@ -207,6 +218,10 @@ main .plans-quote.summary-quote > div.item > div.item-header {
 
 main .plans-quote.summary-quote > div.item > div.item-header > p {
   margin: 1.5rem 0 1.5rem 1.5rem;
+}
+
+main .plans-quote.first-step > div > div:nth-child(2) > div > p:first-of-type {
+  margin-bottom: 0.75rem; /* 12px */
 }
 
 main .plans-quote.summary-quote > div.item > div.item-header > div.item-menu > a {
@@ -275,24 +290,31 @@ main .plans-quote.summary-quote > div.item > div.item-info > div.item-info-heade
   font-weight: 700;
 }
 
-main .plans-quote.summary-quote > div.item > div.auto-renew {
-  display: inline-flex;
+main .plans-quote.summary-quote > div.item > div.auto-renew-container {
   margin: 2.5rem 0;
 }
 
-main .plans-quote.summary-quote > div.item > div.auto-renew > div.auto-renew-checkbox-container {
+main .plans-quote.summary-quote > div.item > div.auto-renew-container > div.auto-renew {
+  display: inline-flex;
+}
+
+main .plans-quote.summary-quote > div.item > div.auto-renew-container > div.auto-renew:not(:first-of-type) {
+  margin: 1.5rem 0 0; /* 24px */
+}
+
+main .plans-quote.summary-quote > div.item > div.auto-renew-container > div.auto-renew > div.auto-renew-checkbox-container {
   margin: .25rem 1rem;
 }
 
-main .plans-quote.summary-quote > div.item > div.auto-renew > div.auto-renew-text {
+main .plans-quote.summary-quote > div.item > div.auto-renew-container > div.auto-renew > div.auto-renew-text {
   margin: 0;
 }
 
-main .plans-quote.summary-quote > div.item > div.auto-renew > div.auto-renew-text ul {
+main .plans-quote.summary-quote > div.item > div.auto-renew-container > div.auto-renew > div.auto-renew-text ul {
   padding-left: 1.5rem;
 }
 
-main .plans-quote.summary-quote > div.item > div.auto-renew > div.auto-renew-info {
+main .plans-quote.summary-quote > div.item > div.auto-renew-container > div.auto-renew > div.auto-renew-info {
   margin: .25rem 4rem;
   width: 1.2rem;
   height: 1.2rem;
@@ -302,7 +324,7 @@ main .plans-quote.summary-quote > div.item > div.auto-renew > div.auto-renew-inf
   position: relative;
 }
 
-main .plans-quote.summary-quote > div.item > div.auto-renew > div.auto-renew-info > div.auto-renew-info-text {
+main .plans-quote.summary-quote > div.item > div.auto-renew-container > div.auto-renew > div.auto-renew-info > div.auto-renew-info-text {
   display: none;
   position: absolute;
   width: 300px;
@@ -316,7 +338,7 @@ main .plans-quote.summary-quote > div.item > div.auto-renew > div.auto-renew-inf
   border-radius: .5rem;
 }
 
-main .plans-quote.summary-quote > div.item > div.auto-renew > div.auto-renew-info:hover > div.auto-renew-info-text {
+main .plans-quote.summary-quote > div.item > div.auto-renew-container > div.auto-renew > div.auto-renew-info:hover > div.auto-renew-info-text {
   display: block;
 }
 
@@ -669,7 +691,7 @@ main div.section.plans-quote-container {
 }
 
 @media (max-width: 768px) {
-  main .plans-quote.summary-quote > div.item > div.auto-renew > div.auto-renew-text {
+  main .plans-quote.summary-quote > div.item > div.auto-renew-container > div.auto-renew > div.auto-renew-text {
     margin: 0 .5rem;
   }
 
@@ -682,7 +704,7 @@ main div.section.plans-quote-container {
     border-radius: 20px;
   }
 
-  main .plans-quote.summary-quote > div.item > div.auto-renew > div.auto-renew-checkbox-container {
+  main .plans-quote.summary-quote > div.item > div.auto-renew-container > div.auto-renew > div.auto-renew-checkbox-container {
     margin: .25rem 1rem 0 0;
   }
 

--- a/scripts/24petwatch-api.js
+++ b/scripts/24petwatch-api.js
@@ -252,9 +252,10 @@ export default class APIClient {
    * @param productId - int
    * @param quantity - int
    * @param isAutoRenew - boolean
+   * @param itemId - string (optional, used for Pumpkin Wellness Club)
    * @returns {Promise<unknown>}
    */
-  saveSelectedProduct(petId, productId, quantity = 1, isAutoRenew = false) {
+  saveSelectedProduct(petId, productId, quantity = 1, isAutoRenew = true, itemId = '') {
     // warning: although this is a POST request, the data is sent as query parameters
 
     const quoteRecId = asInt(productId);
@@ -268,6 +269,12 @@ export default class APIClient {
       quantity: qty,
       autoRenew,
     };
+
+    // if we have a non empty value for itemId
+    if (itemId) {
+      params.itemId = itemId.toString();
+    }
+
     return new Promise((resolve, reject) => {
       APIClient.callAPI(`${this.basePath}/${path}`, APIClient.METHOD_POST, params, null, resolve, reject, 'json');
     });

--- a/scripts/24petwatch-utils.js
+++ b/scripts/24petwatch-utils.js
@@ -13,6 +13,8 @@ export const EMAIL_REGEX = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|
 export const CURRENCY_CANADA = 'CAD';
 export const CURRENCY_US = 'USD';
 
+export const PUMPKIN_ITEM_ID = 'PLH_000016'; // Pumpkin Wellness Club item ID
+
 // ----- general helpers -----
 export function getQueryParam(param, defaultValue = null) {
   const urlParams = new URLSearchParams(window.location.search);
@@ -36,6 +38,7 @@ export const DL_EVENTS = {
 // ----- sessionStorage / localStorage helpers -----
 export const SS_KEY_FORM_ENTRY_URL = 'formEntryURL';
 export const SS_KEY_SUMMARY_ACTION = 'summaryAction';
+export const SS_KEY_AUTO_RENEW_PUMPKIN = 'autoRenewPumpkin';
 export const LS_KEY_COSTCO_FIGO = 'costcoFigoPromo';
 
 // ----- cookie helpers -----


### PR DESCRIPTION
## Azure Ticket ##
[1353](https://dev.azure.com/PetPlaceProduct/24Pet/_workitems/edit/1353)
[1466](https://dev.azure.com/PetPlaceProduct/24Pet/_workitems/edit/1466)

## Purpose ##
Click to cancel updates

## Changes ##

- Required a new auto renew checkbox for PWC and copy updates
- By default, auto renew checkboxes have changes to checked state
- Remember pet autoRenew selections on page refresh (happens when adding new pet)
- PWC required updated API changes with a optional param in payload of the PWC item id

**Fully tested with BE and QA signed off.**

- Before: https://stage--24petwatch--hlxsites.hlx.page/
- After: https://feature-1353-ctc-updates--24petwatch--hlxsites.hlx.page/
