### PR TITLE
fix: pwc optin deploy to main

### DIFF
--- a/blocks/plans-quote/summary-quote.js
+++ b/blocks/plans-quote/summary-quote.js
@@ -12,6 +12,8 @@ import {
   CURRENCY_US,
   SS_KEY_SUMMARY_ACTION,
   DL_EVENTS,
+  PUMPKIN_ITEM_ID,
+  PUMPKIN_DEFAULT_OPTIN,
 } from '../../scripts/24petwatch-utils.js';
 import { isCanada } from '../../scripts/lib-franklin.js';
 import { trackGTMEvent } from '../../scripts/lib-analytics.js';
@@ -489,6 +491,38 @@ export default async function decorateSummaryQuote(block, apiBaseUrl) {
       Loader.hideLoader();
     });
   }
+
+  // foreach pet, set the PWC default opt-in
+  async function setPWCDefaultOptin() {
+    if (petsList.length === 0) {
+      return;
+    }
+
+    petsList.forEach(async (pet) => {
+      const selectedProduct = getSelectedProduct(pet.id);
+      if (!selectedProduct) {
+        return;
+      }
+
+      const { petID, quoteRecId } = selectedProduct;
+
+      try {
+        await APIClientObj.saveSelectedProduct(
+          petID,
+          quoteRecId,
+          1,
+          PUMPKIN_DEFAULT_OPTIN,
+          PUMPKIN_ITEM_ID,
+        );
+      } catch (status) {
+        // eslint-disable-next-line no-console
+        console.log('Failed to update the PWC opt-in for pet:', petID, ' status:', status);
+      }
+    });
+  }
+
+  // set PWC default opt-in
+  setPWCDefaultOptin();
 
   // run a check on all auto-renew checkboxes to save their states
   saveAutoRenewStates();

--- a/blocks/plans-quote/summary-quote.js
+++ b/blocks/plans-quote/summary-quote.js
@@ -521,8 +521,10 @@ export default async function decorateSummaryQuote(block, apiBaseUrl) {
     });
   }
 
-  // set PWC default opt-in
-  setPWCDefaultOptin();
+  // set PWC default opt-in US only
+  if (!isCanada) {
+    setPWCDefaultOptin();
+  }
 
   // run a check on all auto-renew checkboxes to save their states
   saveAutoRenewStates();

--- a/scripts/24petwatch-utils.js
+++ b/scripts/24petwatch-utils.js
@@ -11,6 +11,7 @@ export const EMAIL_REGEX = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|
 export const CURRENCY_CANADA = 'CAD';
 export const CURRENCY_US = 'USD';
 export const PUMPKIN_ITEM_ID = 'PLH_000016'; // Pumpkin Wellness Club item ID
+export const PUMPKIN_DEFAULT_OPTIN = true; // default opt-in for Pumpkin Wellness Club
 export const DNS_PLACEHOLDER = '{DNS}';
 export const DNS_LINK_TEXT = 'Do Not Sell or Share My Personal Information';
 

--- a/scripts/configs.js
+++ b/scripts/configs.js
@@ -8,6 +8,7 @@ export const calcEnvironment = () => {
       'aem-dev\\.24petwatch\\.com': 'dev',
       'aem-stage\\.24petwatch\\.com': 'stage',
       '.*\\.hlx\\.page': 'dev',
+      '.*\\.aem\\.page': 'dev',
       localhost: 'dev',
     };
 


### PR DESCRIPTION
## Ticket ##
[5111](https://dev.azure.com/PetPlaceProduct/24Pet/_workitems/edit/5111)

## Purpose ##
By default a 24PW membership purchase on the data side is setting PWC autorenew as false.

## Changes ##
Rather than make the default setting on BE, we are setting this autorenew with itemId to true on summary page load where it used to be prior to CTC. 
This POST request should happen for US flow only

## Validate Changes ##
Changes are being validated on BE DB and DAX with Howell and Sarath

- Before: https://main--24petwatch--hlxsites.hlx.page/
- After: https://fix-pwc-optin--24petwatch--hlxsites.hlx.page/

